### PR TITLE
Update repo name

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,7 +56,7 @@ jobs:
         path: docs/_build/html/
     - name: Commit documentation changes
       run: |
-        git clone https://github.com/crossnox/m2r.git --branch gh-pages --single-branch gh-pages
+        git clone https://github.com/crossnox/m2r2.git --branch gh-pages --single-branch gh-pages
         cp -r docs/_build/html/* gh-pages/
         cd gh-pages
         git config --local user.email "action@github.com"

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 ## Version 0.3.0
 
+### Version 0.2.5 (2020-07-13)
+* Update repo name in every reference
+
 ### Version 0.2.4 (2020-07-12)
 * Central versioning
 * Add bump

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@ M2R2
 
 [![PyPI](https://img.shields.io/pypi/v/m2r2.svg)](https://pypi.python.org/pypi/m2r2)
 [![PyPI version](https://img.shields.io/pypi/pyversions/m2r2.svg)](https://pypi.python.org/pypi/m2r2)
-[![Documentation](https://img.shields.io/badge/docs-latest-brightgreen.svg)](https://crossnox.github.io/m2r)
-![Python package](https://github.com/CrossNox/m2r/workflows/Python%20package/badge.svg)
+[![Documentation](https://img.shields.io/badge/docs-latest-brightgreen.svg)](https://crossnox.github.io/m2r2)
+![Python package](https://github.com/CrossNox/m2r2/workflows/Python%20package/badge.svg)
 
 --------------------------------------------------------------------------------
 
@@ -151,12 +151,12 @@ in the markdown file, please use `.. mdinclude:: file` instead.
   * H1: `=`, H2: `-`, H3: `^`, H4: `~`, H5: `"`, H6: `#`
 
 If you find any bug or unexpected behaviour, please report it to
-[Issues](https://github.com/crossnox/m2r/issues).
+[Issues](https://github.com/crossnox/m2r2/issues).
 
 ## Example
 
-See [example document](https://crossnox.github.io/m2r/example.html) and [its
-source code](https://github.com/crossnox/m2r/blob/master/docs/example.md).
+See [example document](https://crossnox.github.io/m2r2/example.html) and [its
+source code](https://github.com/crossnox/m2r2/blob/master/docs/example.md).
 
 *Note from the original author:* I'm using m2r for writing user guide of [WDOM](https://github.com/miyakogi/wdom).
 So you can see it as another example. Its [HTML is

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -133,7 +133,7 @@ html_theme = 'alabaster'
 html_theme_options = {
     'description': 'Markdown mixed to reST',
     'github_user': 'CrossNox',
-    'github_repo': 'm2r',
+    'github_repo': 'm2r2',
     'github_banner': True,
     'github_type': 'mark',
     'github_count': False,

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     author_email="miyako.dev@gmail.com",
     maintainer="CrossNox",
     maintainer_email="ijmermet+m2r2@gmail.com",
-    url="https://github.com/crossnox/m2r",
+    url="https://github.com/crossnox/m2r2",
     py_modules=["m2r2"],
     entry_points={"console_scripts": "m2r2 = m2r2:main"},
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ except ImportError:
         readme = f.read()
 
 
-__version__ = "0.2.4"
+__version__ = "0.2.5"
 
 install_requires = ["mistune", "docutils"]
 test_requirements = ["pygments"]


### PR DESCRIPTION
To avoid any confusion, I'm updating the repo name, which [should not break clones](https://github.blog/2013-05-16-repository-redirects-are-here/). This PR updates any relevant reference. 