### PR TITLE
fix: sphinx finally deprecated old `add_source_parser` in 3.3, returning `AttributeError`

### DIFF
--- a/m2r2.py
+++ b/m2r2.py
@@ -662,7 +662,7 @@ def setup(app):
     app.add_config_value("m2r_disable_inline_math", False, "env")
     try:
         app.add_source_parser(".md", M2RParser)  # for older sphinx versions
-    except TypeError:
+    except (TypeError, AttributeError):
         app.add_source_suffix(".md", "markdown")
         app.add_source_parser(M2RParser)
     app.add_directive("mdinclude", MdInclude)


### PR DESCRIPTION
This addresses https://github.com/CrossNox/m2r2/issues/13

Given `add_source_parser()` in sphinx 3.3 has changed the signature (https://github.com/sphinx-doc/sphinx/pull/8280), invocations with the extra params result in `AttributeError` exceptions, not `TypeError`, so adding this condition to the failback logic to consume the latest signature when that occurs.