### PR TITLE
Swap backticks and dollar signs in inline math markup

### DIFF
--- a/m2r2.py
+++ b/m2r2.py
@@ -110,10 +110,10 @@ class RestInlineGrammar(mistune.InlineGrammar):
     )
     rest_role = re.compile(r":.*?:`.*?`|`[^`]+`:.*?:")
     rest_link = re.compile(r"`[^`]*?`_")
-    inline_math = re.compile(r"`\$(.*)?\$`")
+    inline_math = re.compile(r"\$`(.*)?`\$")
     eol_literal_marker = re.compile(r"(\s+)?::\s*$")
-    # add colon and space as special text
-    text = re.compile(r"^[\s\S]+?(?=[\\<!\[:_*`~ ]|https?://| {2,}\n|$)")
+    # add colon, dollar and space as special text
+    text = re.compile(r"^[\s\S]+?(?=[\\<!\[:_*`~$ ]|https?://| {2,}\n|$)")
     # __word__ or **word**
     double_emphasis = re.compile(r"^([_*]){2}(?P<text>[\s\S]+?)\1{2}(?!\1)")
     # _word_ or *word*

--- a/tests/test.md
+++ b/tests/test.md
@@ -8,4 +8,4 @@ __content__
 
 [A link to GitHub](http://github.com/)
 
-This is `$E = mc^2$` inline math.
+This is $`E = mc^2`$ inline math.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -136,5 +136,5 @@ class TestConvert(TestCase):
         sys.argv = [sys.argv[0], '--disable-inline-math', '--dry-run', test_md]
         with patch(_builtin + '.print') as m:
             main()
-        self.assertIn('``$E = mc^2$``', m.call_args[0][0])
+        self.assertIn(r'$\ ``E = mc^2``\ $', m.call_args[0][0])
         self.assertNotIn(':math:', m.call_args[0][0])

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -264,14 +264,14 @@ class TestInlineMarkdown(RendererTestBase):
         self.assertEqual(out, '\na ``code`` and `RefLink <a>`_ here.\n')
 
     def test_inline_math(self):
-        src = 'this is `$E = mc^2$` inline math.'
+        src = 'this is $`E = mc^2`$ inline math.'
         out = self.conv(src)
         self.assertEqual(out, '\nthis is :math:`E = mc^2` inline math.\n')
 
     def test_disable_inline_math(self):
-        src = 'this is `$E = mc^2$` inline math.'
+        src = 'this is $`E = mc^2`$ inline math.'
         out = self.conv(src, disable_inline_math=True)
-        self.assertEqual(out, '\nthis is ``$E = mc^2$`` inline math.\n')
+        self.assertEqual(out, '\nthis is $\\ ``E = mc^2``\\ $ inline math.\n')
 
     def test_inline_html(self):
         src = 'this is <s>html</s>.'


### PR DESCRIPTION
Switches the inline math markup to match gitlab:s style. Fixes https://github.com/CrossNox/m2r2/issues/20.