### PR TITLE
Don't try to import m2r2 during setup (fixes DistributionNotFound error)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,13 +10,8 @@ except ImportError:
     from distutils.core import setup
 
 readme_file = path.join(path.dirname(path.abspath(__file__)), "README.md")
-try:
-    from m2r2 import parse_from_file
-
-    readme = parse_from_file(readme_file)
-except ImportError:
-    with open(readme_file) as f:
-        readme = f.read()
+with open(readme_file) as f:
+    readme = f.read()
 
 
 __version__ = "0.2.5"


### PR DESCRIPTION
Don't try to import m2r2 during setup, since it expects m2r2 to be
installed already.

Fixes the following error during `pip install https://github.com/CrossNox/m2r2/archive/v0.2.7.zip`:
```
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-req-build-ga0ueyp7/setup.py", line 14, in <module>
        from m2r2 import parse_from_file
      File "/tmp/pip-req-build-ga0ueyp7/m2r2.py", line 19, in <module>
        __version__ = get_distribution("m2r2").version
      File "/home/chn/env/lib/python3.8/site-packages/pkg_resources/__init__.py", line 480, in get_distribution
        dist = get_provider(dist)
      File "/home/chn/env/lib/python3.8/site-packages/pkg_resources/__init__.py", line 356, in get_provider
        return working_set.find(moduleOrReq) or require(str(moduleOrReq))[0]
      File "/home/chn/env/lib/python3.8/site-packages/pkg_resources/__init__.py", line 899, in require
        needed = self.resolve(parse_requirements(requirements))
      File "/home/chn/env/lib/python3.8/site-packages/pkg_resources/__init__.py", line 785, in resolve
        raise DistributionNotFound(req, requirers)
    pkg_resources.DistributionNotFound: The 'm2r2' distribution was not found and is required by the application
```