### PR TITLE
Update for docutils 0.19

### DIFF
--- a/m2r2.py
+++ b/m2r2.py
@@ -11,9 +11,8 @@ from argparse import ArgumentParser, Namespace
 
 import mistune
 from docutils import io, nodes, statemachine, utils
-from docutils.core import ErrorString
 from docutils.parsers import rst
-from docutils.utils import SafeString, column_width
+from docutils.utils import column_width
 from pkg_resources import get_distribution
 
 __version__ = get_distribution("m2r2").version
@@ -621,12 +620,12 @@ class MdInclude(rst.Directive):
             raise self.severe(
                 'Problems with "%s" directive path:\n'
                 'Cannot encode input file path "%s" '
-                "(wrong locale?)." % (self.name, SafeString(path))
+                "(wrong locale?)." % (self.name, str(path))
             )
         except IOError as error:
             raise self.severe(
                 'Problems with "%s" directive path:\n%s.'
-                % (self.name, ErrorString(error))
+                % (self.name, io.error_string(error))
             )
 
         # read from the file
@@ -640,7 +639,7 @@ class MdInclude(rst.Directive):
                 rawtext = include_file.read()
         except UnicodeError as error:
             raise self.severe(
-                'Problem with "%s" directive:\n%s' % (self.name, ErrorString(error))
+                'Problem with "%s" directive:\n%s' % (self.name, io.error_string(error))
             )
 
         config = self.state.document.settings.env.config


### PR DESCRIPTION
ErrorString and SafeString are deprecated and have been removed in docutils 0.19. This PR replaces `ErrorString` with `io.error_string` and `SafeString` with Python's builtin `str()`.

See [docutils:HISTORY.txt](https://sourceforge.net/p/docutils/code/HEAD/tree/trunk/docutils/HISTORY.txt) and [docutils:utils/error_reporting.py](https://sourceforge.net/p/docutils/code/HEAD/tree/tags/docutils-0.19/docutils/utils/error_reporting.py) for more information.