### PR TITLE
Added python_requires to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,4 +59,5 @@ setup(
     install_requires=install_requires,
     test_suite="tests",
     tests_require=test_requirements,
+    python_requires='>=3.7',
 )


### PR DESCRIPTION
Version 0.3.3 is offered to Python 2.7's pip, which is wrong as it isn't compatible. This clause should prevent pip from trying to install this version. More info at https://stackoverflow.com/a/42792413/1076564 .

I'm not sure how exactly it behaves, but it's possible that version 0.3.3 would need to be re-releases with this fix, of a new version released and 0.3.3 withdrawn.