### PR TITLE
Switch to single-dollar inline math markup

### DIFF
--- a/m2r2.py
+++ b/m2r2.py
@@ -119,10 +119,14 @@ class RestInlineGrammar(mistune.InlineGrammar):
     )
     rest_role = re.compile(r":.*?:`.*?`|`[^`]+`:.*?:")
     rest_link = re.compile(r"`[^`]*?`_")
-    inline_math = re.compile(r"`\$(.*?)\$`")
+
+    # Inline math pattern is based on the Pandoc heuristics:
+    # https://pandoc.org/MANUAL.html#extension-tex_math_dollars
+    inline_math = re.compile(r"\$(\S[^$\n]*\S|[^$\s])\$")
+
     eol_literal_marker = re.compile(r"(\s+)?::\s*$")
-    # add colon and space as special text
-    text = re.compile(r"^[\s\S]+?(?=[\\<!\[:_*`~ ]|https?://| {2,}\n|$)")
+    # add colon, dollar and space as special text
+    text = re.compile(r"^[\s\S]+?(?=[\\<!\[:_*`~$ ]|https?://| {2,}\n|$)")
     # __word__ or **word**
     double_emphasis = re.compile(r"^([_*]){2}(?P<text>[\s\S]+?)\1{2}(?!\1)")
     # _word_ or *word*

--- a/tests/test.md
+++ b/tests/test.md
@@ -8,11 +8,11 @@ __content__
 
 [A link to GitHub](http://github.com/)
 
-This is `$E = mc^2$` inline math.
+This is $E = mc^2$ inline math.
 
-This first math `$x^2$` in this line will render. This one `$z^3$` should as well.
+This first math $x^2$ in this line will render. This one $z^3$ should as well.
 
-Also within parentheses (`$x^2$`) and (`$z^3$`).
+Also within parentheses ($x^2$) and ($z^3$).
 
 ```mermaid
 graph TD;

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -136,5 +136,5 @@ class TestConvert(TestCase):
         sys.argv = [sys.argv[0], '--disable-inline-math', '--dry-run', test_md]
         with patch(_builtin + '.print') as m:
             main()
-        self.assertIn('``$E = mc^2$``', m.call_args[0][0])
+        self.assertIn(r'$E = mc^2$', m.call_args[0][0])
         self.assertNotIn(':math:', m.call_args[0][0])

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -264,14 +264,22 @@ class TestInlineMarkdown(RendererTestBase):
         self.assertEqual(out, '\na ``code`` and `RefLink <a>`_ here.\n')
 
     def test_inline_math(self):
-        src = 'this is `$E = mc^2$` inline math.'
+        src = 'this is $E = mc^2$ inline math.'
         out = self.conv(src)
         self.assertEqual(out, '\nthis is :math:`E = mc^2` inline math.\n')
 
+        self.assertEqual(self.conv('$ee$'), '\n:math:`ee`\n')
+        self.assertEqual(self.conv('$e$'), '\n:math:`e`\n')
+
+    def test_inline_math_money(self):
+        src = 'Thus, $20,000 and $30,000 won’t parse as math'
+        out = self.conv(src)
+        self.assertEqual(out, '\nThus, $20,000 and $30,000 won’t parse as math\n')
+
     def test_disable_inline_math(self):
-        src = 'this is `$E = mc^2$` inline math.'
+        src = 'this is $E = mc^2$ inline math.'
         out = self.conv(src, disable_inline_math=True)
-        self.assertEqual(out, '\nthis is ``$E = mc^2$`` inline math.\n')
+        self.assertEqual(out, '\nthis is $E = mc^2$ inline math.\n')
 
     def test_inline_html(self):
         src = 'this is <s>html</s>.'


### PR DESCRIPTION
Fixes #20 in a backwards-incompatible way.