### PR TITLE
Avoid docutils.nodes.reprunicode

### DIFF
--- a/m2r2.py
+++ b/m2r2.py
@@ -10,7 +10,7 @@ import sys
 from argparse import ArgumentParser, Namespace
 
 import mistune
-from docutils import io, nodes, statemachine, utils
+from docutils import io, statemachine, utils
 from docutils.parsers import rst
 from docutils.utils import column_width
 from pkg_resources import get_distribution
@@ -608,7 +608,6 @@ class MdInclude(rst.Directive):
         path = rst.directives.path(self.arguments[0])
         path = os.path.normpath(os.path.join(source_dir, path))
         path = utils.relative_path(None, path)
-        path = nodes.reprunicode(path)
 
         # get options (currently not use directive-specific options)
         encoding = self.options.get(


### PR DESCRIPTION
`docutils.nodes.reprunicode` was until recently just a subclass of `str`. It was removed in this commit: https://sourceforge.net/p/docutils/code/9415/ Therefore `path = nodes.reprunicode(path)` just converted a string to a string and can therefore be removed.

This is an alternative to fixing `docutils` to an old version (as done in #69).

Related discussion on a similar issue with another Sphinx project: https://github.com/orgs/sphinx-doc/discussions/13020#discussioncomment-10930769

Fixes #68