### PR TITLE
fallback to importlib.metadata

### DIFF
--- a/m2r2.py
+++ b/m2r2.py
@@ -13,7 +13,11 @@ import mistune
 from docutils import io, nodes, statemachine, utils
 from docutils.parsers import rst
 from docutils.utils import column_width
-from pkg_resources import get_distribution
+
+try:
+    from pkg_resources import get_distribution
+except ImportError:
+    from importlib.metadata import distribution as get_distribution
 
 __version__ = get_distribution("m2r2").version
 


### PR DESCRIPTION
Currently, `m2r2` fails to import if your project doesn't depend on `setuptools` (which used to be included with python by default, but no longer).

The issue suggests to add `setuptools` as a dependency, but I'm proposing to fallback to `importlib.metadata` which was (informally) added in Python 3.8. Presumably, if you're on Python <=3.7, you'll have pkg_resources and can use that instead.

Fixes #63

## Local testing

First, I confirm that `pkg_resources` isn't present. Then, I show that you can still import `m2r2` and the version is properly set.

```pycon
>>> import pkg_resources
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ModuleNotFoundError: No module named 'pkg_resources'
>>> import m2r2
>>> m2r2.__version__
'0.3.3.post2'
```